### PR TITLE
Remove dead code and simplify in preparation for major API refactor

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -150,14 +150,6 @@ export interface RelationshipDescriptor<
  * union of their **constructed** (output) value types.  Intended for use with
  * {@link Schema.Of} when building explicit discriminated unions:
  *
- * ```ts
- * class A extends Schema.from({ kind: Of<'A'>() }) {}
- * class B extends Schema.from({ kind: Of<'B'>() }) {}
- *
- * type AorB = DiscriminatedUnion<[typeof A, typeof B]>;
- * //        ^ equivalent to  OutputOf<typeof A> | OutputOf<typeof B>
- * ```
- *
  * Internally this is merely an alias over `OutputOf<…>` – no additional runtime
  * behaviour is attached.  Validation, serialisation, and re-hydration are
  * handled by the {@link Schema} logic once the corresponding `schemaClasses`
@@ -167,14 +159,3 @@ export interface RelationshipDescriptor<
 export type Variant<
   Classes extends readonly { new (input: any): SchemaInstance }[],
 > = OutputOf<Classes[number]>;
-
-/**
- * Deprecated alias kept for smoother migration. Instantiating the runtime
- * value throws immediately with a descriptive error so that code relying on
- * the *value* (rather than the type) fails loudly.
- */
-
-// NOTE: The old `DiscriminatedUnion` runtime shim and type alias were removed.
-// If you still reference `DiscriminatedUnion` in user-land code, migrate to
-// the new `Variant` helper which provides the same compile-time behaviour
-// without the deprecated API surface.

--- a/tests/schema.nestedArrayWithOptions.test.ts
+++ b/tests/schema.nestedArrayWithOptions.test.ts
@@ -8,8 +8,8 @@ const validLogin = (val: LoginAttempt): true | string => {
 };
 
 class LoginAttempt extends Schema.from({
-  success: Of.boolean(),
-  unixTimestampMs: Of.number(),
+  success: Of<boolean>(),
+  unixTimestampMs: Of<number>(),
 }) {}
 
 class User extends Schema.from({

--- a/tests/schema.primitiveStrict.test.ts
+++ b/tests/schema.primitiveStrict.test.ts
@@ -3,9 +3,8 @@ import { describe, it, expect } from "vitest";
 import { Schema, Of } from "@rybosome/type-a";
 
 class Flags extends Schema.from({
-  // Use strict primitive helpers so runtime validation rejects incorrect types
-  active: Of.boolean(),
-  score: Of.number(),
+  active: Of<boolean>(),
+  score: Of<number>(),
 }) {}
 
 describe("Schema – strict primitive validation", () => {

--- a/tests/schema.relationships.test.ts
+++ b/tests/schema.relationships.test.ts
@@ -3,8 +3,8 @@ import { describe, it, expect } from "vitest";
 import { Schema, Of } from "@rybosome/type-a";
 
 class LoginAttempt extends Schema.from({
-  success: Of.boolean(),
-  unixTimestampMs: Of.number(),
+  success: Of<boolean>(),
+  unixTimestampMs: Of<number>(),
 }) {}
 
 class LoginRecord extends Schema.from({

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -8,8 +8,8 @@ import { Schema, Of, aUUID, atLeast } from "@rybosome/type-a";
 describe("Schema", () => {
   describe("basic functionality", () => {
     class User extends Schema.from({
-      id: Of.string({ is: aUUID }),
-      age: Of.number({ is: atLeast(18) }),
+      id: Of<string>({ is: aUUID }),
+      age: Of<number>({ is: atLeast(18) }),
       active: Of<boolean>({ default: true }), // default added here
     }) {
       greet() {
@@ -55,7 +55,7 @@ describe("Schema", () => {
   describe("optional & nullable fields", () => {
     class OptModel extends Schema.from({
       // required – no default and `undefined` not allowed
-      required: Of.string(),
+      required: Of<string>(),
 
       // optional – `undefined` explicitly allowed
       optional: Of<string | undefined>(),

--- a/tests/schema.variant.test.ts
+++ b/tests/schema.variant.test.ts
@@ -4,12 +4,12 @@ import { Schema, Of, Variant } from "@rybosome/type-a";
 
 class A extends Schema.from({
   kind: Of<"A">(), // keep literal helper via generic – still ok
-  a: Of.string(),
+  a: Of<string>(),
 }) {}
 
 class B extends Schema.from({
   kind: Of<"B">(),
-  b: Of.number(),
+  b: Of<number>(),
 }) {}
 
 class Wrapper extends Schema.from({


### PR DESCRIPTION
Removes dead code in preparation for a major API refactor - all of the unused code was making it difficult to get things done.

However, this leaves two tests failing.