### PR TITLE
Split types out from schema file, prep for further refactors

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,7 +14,7 @@
  * {@link defaultRegistry} when none is provided).
  */
 
-import type { SchemaClass } from "@src/schema";
+import type { SchemaClass } from "@src/types";
 
 /** Shape exported only for typing – implementation is the built-in `WeakMap`. */
 export type Registry = WeakMap<

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface SchemaInstance {
 /**
  * The subset of values that may appear in a scalar schema field.
  */
-type ScalarTypeable =
+export type ScalarTypeable =
   | string
   | number
   | bigint
@@ -31,7 +31,7 @@ type ScalarTypeable =
  * practice it keeps the definition mathematically complete and prevents
  * surprises when generic tuples collapse to `never[]` or `[]` in edge-cases.
  */
-type TupleTypeable =
+export type TupleTypeable =
   | readonly []
   | readonly [ScalarTypeable, ...ScalarTypeable[]];
 
@@ -159,3 +159,190 @@ export interface RelationshipDescriptor<
 export type Variant<
   Classes extends readonly { new (input: any): SchemaInstance }[],
 > = OutputOf<Classes[number]>;
+
+/**
+ * Helper aliases used by the `Of<T>` overloads below.  They enforce whether
+ * the caller supplied a `default` as well as whether a `[serializer,
+ * deserializer]` tuple is present.
+ */
+export type FieldWithDefault<T extends Typeable, R = T> = FieldType<T, R> & {
+  default: T | (() => T);
+};
+
+/**
+ * Field descriptor *without* a default.
+ */
+export type FieldWithoutDefault<T extends Typeable, R = T> = Omit<
+  FieldType<T, R>,
+  "default"
+>;
+
+// --------------------
+// FieldType
+// --------------------
+
+/**
+ * A field description used by Schema.
+ */
+/**
+ * Describes a Schema property at both compile-time (for type inference/validation)
+ * and runtime (for parsing/validation/serialization).
+ *
+ * @typeParam T   The *in-memory* typed representation used by callers once the
+ *                value has been parsed/deserialised.
+ * @typeParam R   The *raw* external representation accepted by the constructor
+ *                **and** produced by the optional `serializer`.  When no
+ *                custom serialisation is supplied `R` defaults to `T` so
+ *                existing call-sites continue to compile unchanged.
+ */
+export interface FieldType<T extends Typeable, R = T> {
+  /**
+   * Compile-time marker that preserves the **exact** generic parameter `T`
+   * (including `undefined`) during conditional-type inference via `FieldType<infer V>`.
+   *
+   * This is a phantom property: it exists only at the type level and is never
+   * assigned or accessed at runtime.
+   *
+   * Although **required** in the type, every real object is produced via a
+   * type-assertion (`as FieldType<T>`) so no property is emitted.
+   */
+  readonly __t: T;
+
+  /**
+   * The underlying value contained in the field.  In addition to primitive
+   * scalars and flat arrays, **tuple** values (both fixed-length and variadic
+   * rest-pattern forms) are fully supported via the extended {@link Typeable}
+   * definition.
+   */
+  value: T | undefined;
+
+  /**
+   * Optional default value applied when the caller omits the field or passes
+   * `undefined`. The default may be the value itself **or** a zero-arg function
+   * returning the value (useful for non-primitive or non-constant defaults).
+   */
+  default?: T | (() => T);
+
+  /**
+   * Optional validator(s). When an array is provided, every constraint is run
+   * in order until the first failure (the returned string) or until all pass
+   * (returns `true`).
+   */
+  is?: LogicalConstraint<NonNullable<T>> | LogicalConstraint<NonNullable<T>>[];
+
+  /**
+   * Optional nested Schema class (singular). When present this field is
+   * automatically instantiated, validated and serialised recursively.
+   */
+  schemaClass?: SchemaClass;
+
+  /**
+   * Optional *set* of Schema classes used for explicit variant unions. When
+   * provided the runtime picks the correct constructor from this list based on
+   * the incoming raw object's discriminator value (see {@link variantKey}) and
+   * instantiates it.  Mutually exclusive with {@link FieldType.schemaClass}.
+   */
+  variantClasses?: SchemaClass[];
+
+  /**
+   * Optional custom serialisation/deserialisation tuple applied to the raw
+   * value during `Schema` construction and when calling `toJSON()`.  The first
+   * element is the **deserialiser** (raw -> in-memory), the second is the
+   * **serialiser** (in-memory -> raw).
+   */
+  serdes?: [(raw: R) => T, (val: T) => R];
+
+  /**
+   * Relationship descriptor produced by {@link Schema.hasOne} /
+   * {@link Schema.hasMany}.  Included primarily for registry bookkeeping – the
+   * core runtime logic uses {@link schemaClass} and the field's generic type
+   * (array vs scalar) for instantiation.
+   */
+  relation?: RelationshipDescriptor<any>;
+}
+
+/**
+ * Run-time shape of a Schema class (produced by {@link Schema.from}).
+ */
+export type SchemaClass = {
+  new (input: any): SchemaInstance;
+  _schema: Fields;
+};
+
+export type Nested<S extends SchemaClass> = InputOf<S> | InstanceType<S>;
+
+export type Fields = Record<string, FieldType<any>>;
+
+export type ValueType<F> = F extends { schemaClass: infer S }
+  ? S extends SchemaClass
+    ? F extends FieldType<infer V>
+      ? V // Preserve generic param (handles arrays automatically)
+      : OutputOf<S>
+    : never
+  : F extends { variantClasses: infer Arr }
+    ? Arr extends SchemaClass[]
+      ? F extends FieldType<infer V>
+        ? V extends any[]
+          ? OutputOf<Arr[number]>[]
+          : OutputOf<Arr[number]>
+        : OutputOf<Arr[number]>
+      : never
+    : F extends FieldType<infer V>
+      ? V
+      : never;
+
+export type ValueMap<F extends Fields> = { [K in keyof F]: ValueType<F[K]> };
+
+/**
+ * Keys that are optional in the constructor's input object.
+ *
+ * A key is optional when the field descriptor provides a `default`, or the declared
+ * value type already allows `undefined`.
+ */
+export type OptionalKeys<F extends Fields> = {
+  [K in keyof F]: F[K] extends { default: any }
+    ? K
+    : undefined extends ValueMap<F>[K]
+      ? K
+      : never;
+}[keyof F];
+
+/**
+ * Keys that must be provided in the constructor's input object.
+ */
+export type RequiredKeys<F extends Fields> = {
+  [K in keyof F]: F[K] extends { default: any }
+    ? never
+    : undefined extends ValueMap<F>[K]
+      ? never
+      : K;
+}[keyof F];
+
+/**
+ * Constructor input map:
+ *  • Keys in `RequiredKeys` are mandatory.
+ *  • Keys in `OptionalKeys` may be omitted.
+ */
+export type InputType<F> = F extends { schemaClass: infer S }
+  ? S extends SchemaClass
+    ? F extends FieldType<infer V>
+      ? V extends any[]
+        ? InputOf<S>[]
+        : InputOf<S>
+      : never
+    : never
+  : F extends { variantClasses: infer Arr }
+    ? Arr extends SchemaClass[]
+      ? F extends FieldType<infer V>
+        ? V extends any[]
+          ? InputOf<Arr[number]>[]
+          : InputOf<Arr[number]>
+        : InputOf<Arr[number]>
+      : never
+    : ValueType<F>;
+
+export type InputValueMap<F extends Fields> = {
+  [K in RequiredKeys<F>]: InputType<F[K]>;
+} & {
+  [K in OptionalKeys<F>]?: InputType<F[K]>;
+};


### PR DESCRIPTION
Split types and the schema code into their own files, in prep for further refactors