### PR TITLE
Re-enable docs tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "check": "pnpm typecheck && pnpm lint && pnpm format",
     "go": "tsx src/main.ts",
     "test": "pnpm check && pnpm build && vitest --run && pnpm docs:test",
-    "docs:test": "echo 'docs tests disabled under API v2 migration'"
+    "docs:test": "tsx ./scripts/docs-test.ts"
   },
   "packageManager": "pnpm@10.11.1",
   "devDependencies": {


### PR DESCRIPTION
Fixes the docs tests and re-enables them now that the large API churn is over